### PR TITLE
Update Reaction path for 1.14.1

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/server/api";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 Reaction.Endpoints.add("get", "/health", (req, res) => {
     Reaction.Endpoints.sendResponse(res, {


### PR DESCRIPTION
Reaction API path was outdated in `register.js`. This PR updates it to the new one.